### PR TITLE
feat: add update-checker widget and auto-release CI

### DIFF
--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -1,0 +1,40 @@
+name: Release Plugins
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Tag and release plugins
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for pkg in plugins/*/package.json; do
+            plugin=$(echo "$pkg" | cut -d'/' -f2)
+            version=$(jq -r '.version' "$pkg")
+            tag="${plugin}@${version}"
+
+            if git tag -l "$tag" | grep -q .; then
+              echo "⏭ $tag already exists, skipping"
+              continue
+            fi
+
+            echo "🏷 Creating release $tag"
+            git tag "$tag"
+            git push origin "$tag"
+
+            gh release create "$tag" \
+              --title "$plugin v$version" \
+              --notes "Release $plugin v$version" \
+              --target main
+          done

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -1,0 +1,24 @@
+name: Sync develop with main
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Merge main into develop
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git merge origin/main --no-edit
+          git push origin develop

--- a/README.md
+++ b/README.md
@@ -5,4 +5,25 @@
 | \ | Name | Portal |
 |---|------|--------|
 | <img src="https://raw.githubusercontent.com/browneyedsoul/trilium-plugins/main/plugins/outliner/public/logo.svg" width="75" height="75" /> | Trilium Outliner | [Link](https://github.com/browneyedsoul/trilium-plugins/tree/main/plugins/outliner) |
-| Soon | It will be added more soon | Link |
+| <img src="https://raw.githubusercontent.com/browneyedsoul/trilium-plugins/main/plugins/update-checker/public/logo.svg" width="75" height="75" /> | Trilium Update Checker | [Link](https://github.com/browneyedsoul/trilium-plugins/tree/main/plugins/update-checker) |
+
+## Update Checker
+
+### How to Install
+
+To receive update notifications for installed plugins:
+
+1. Create a new **Code Note** in Trilium.
+2. Set the note type to **JSX**.
+3. Paste the [update-checker code](https://github.com/browneyedsoul/trilium-plugins/tree/main/plugins/update-checker/trilium-update-checker.jsx) into the note.
+4. Add the label `#widget` to that note.
+5. Refresh Trilium.
+
+Installed plugins automatically register their versions. When a newer version is released, a toast notification will appear in the bottom-right corner with a link to the release page.
+
+### How to Update a Plugin
+
+1. Click the **Release** link in the toast notification.
+2. Copy the latest plugin code from the release page.
+3. Paste it into the existing Code Note in Trilium, replacing the old code.
+4. Refresh Trilium.

--- a/plugins/outliner/package.json
+++ b/plugins/outliner/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "trilium-outliner",
+  "version": "1.0.0",
+  "description": "A Plugin which automatically indents content based on heading level",
+  "author": "browneyedsoul",
+  "license": "MIT"
+}

--- a/plugins/outliner/trilium-outliner.js
+++ b/plugins/outliner/trilium-outliner.js
@@ -6,9 +6,13 @@ class OutlineByHeadingWidget extends api.NoteContextAwareWidget {
     return 100
   }
 
+  static get VERSION() { return '1.0.0' }
+  static get PLUGIN_NAME() { return 'outliner' }
+
   constructor() {
     super()
     this.contentSized()
+    localStorage.setItem(`trilium-plugin-${OutlineByHeadingWidget.PLUGIN_NAME}`, OutlineByHeadingWidget.VERSION)
 
     // ====== 설정 ======
     this.ACTIVATE_LABEL = null // (null 은 어디든 / "outline" 은 #outline 일 때만)

--- a/plugins/soon/soon.js
+++ b/plugins/soon/soon.js
@@ -1,1 +1,0 @@
-console.log("Soon plugin loaded.");

--- a/plugins/update-checker/README.md
+++ b/plugins/update-checker/README.md
@@ -1,0 +1,22 @@
+# Trilium Update Checker
+
+A widget that checks for plugin updates by comparing installed versions against GitHub release tags.
+
+## How It Works
+
+1. On load, it fetches tags from the GitHub repository.
+2. Compares each plugin's installed version against the latest tag (e.g. `outliner@1.1.0`).
+3. If a newer version exists, a toast notification appears in the bottom-right corner.
+4. Checks once every 24 hours (cached via localStorage).
+
+## How to Use
+
+1. Create a new **Code Note** in Trilium.
+2. Set the note type to `JSX`.
+3. Paste the plugin code into the note.
+4. Add the label `#widget` to that note.
+5. Refresh Trilium.
+
+## How It Detects Installed Plugins
+
+Each plugin registers its name and version to localStorage on load (e.g. `trilium-plugin-outliner: "1.0.0"`). The update checker automatically discovers all registered plugins and compares their versions against GitHub tags. No manual configuration needed.

--- a/plugins/update-checker/package.json
+++ b/plugins/update-checker/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "trilium-update-checker",
+  "version": "1.0.0",
+  "description": "A widget that checks for plugin updates via GitHub tags",
+  "author": "browneyedsoul",
+  "license": "MIT"
+}

--- a/plugins/update-checker/public/logo.svg
+++ b/plugins/update-checker/public/logo.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="Trilium Update Checker logo">
+  <title>Trilium Update Checker</title>
+
+  <!-- rounded tile -->
+  <rect x="8" y="8" width="112" height="112" rx="24" fill="none" stroke="#777" stroke-width="8"></rect>
+
+  <!-- circular arrow (refresh/update) -->
+  <path d="M64 36 A28 28 0 1 1 36 64" fill="none" stroke="#888" stroke-width="8" stroke-linecap="round"></path>
+  <polygon points="36,48 36,68 52,58" fill="#888"></polygon>
+
+  <!-- check mark -->
+  <path d="M52 68 L62 78 L80 56" fill="none" stroke="#888" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"></path>
+</svg>

--- a/plugins/update-checker/trilium-update-checker.jsx
+++ b/plugins/update-checker/trilium-update-checker.jsx
@@ -1,0 +1,118 @@
+import { defineWidget, useState, useEffect } from "trilium:preact";
+
+const REPO = 'browneyedsoul/trilium-plugins'
+const CHECK_INTERVAL = 24 * 60 * 60 * 1000
+const CACHE_KEY = 'trilium-plugins-update-check'
+
+const PLUGINS = [
+  { name: 'outliner', version: '1.0.0' },
+]
+
+const compareVersions = (a, b) => {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) > (pb[i] || 0)) return 1
+    if ((pa[i] || 0) < (pb[i] || 0)) return -1
+  }
+  return 0
+}
+
+const checkForUpdates = async () => {
+  const lastCheck = localStorage.getItem(CACHE_KEY)
+  if (lastCheck && Date.now() - Number(lastCheck) < CHECK_INTERVAL) return []
+
+  localStorage.setItem(CACHE_KEY, String(Date.now()))
+
+  try {
+    const res = await fetch(`https://api.github.com/repos/${REPO}/tags`)
+    if (!res.ok) return []
+
+    const tags = (await res.json()).map(t => t.name)
+    const updates = []
+
+    for (const plugin of PLUGINS) {
+      const prefix = `${plugin.name}@`
+      const versions = tags
+        .filter(t => t.startsWith(prefix))
+        .map(t => t.slice(prefix.length))
+        .sort(compareVersions)
+
+      if (versions.length === 0) continue
+
+      const latest = versions[versions.length - 1]
+      if (compareVersions(latest, plugin.version) > 0) {
+        updates.push({
+          name: plugin.name,
+          current: plugin.version,
+          latest,
+          tag: `${prefix}${latest}`,
+        })
+      }
+    }
+
+    return updates
+  } catch (_) {
+    return []
+  }
+}
+
+const toastStyle = {
+  position: 'fixed',
+  bottom: '20px',
+  right: '20px',
+  zIndex: 99999,
+  background: '#1e1e1e',
+  color: '#ccc',
+  border: '1px solid #444',
+  borderRadius: '8px',
+  padding: '14px 18px',
+  fontSize: '13px',
+  maxWidth: '360px',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
+}
+
+const UpdateToast = () => {
+  const [updates, setUpdates] = useState([])
+  const [visible, setVisible] = useState(true)
+
+  useEffect(() => {
+    checkForUpdates().then(setUpdates)
+  }, [])
+
+  if (updates.length === 0 || !visible) return null
+
+  return (
+    <div style={toastStyle}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
+        <strong style={{ color: '#e6e6e6' }}>Plugin updates available</strong>
+        <button
+          onClick={() => setVisible(false)}
+          style={{ background: 'none', border: 'none', color: '#aaa', cursor: 'pointer', fontSize: '16px' }}
+        >
+          ✕
+        </button>
+      </div>
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+        {updates.map(u => (
+          <li key={u.name} style={{ margin: '4px 0' }}>
+            <strong>{u.name}</strong> v{u.current} → v{u.latest}
+            <a
+              href={`https://github.com/${REPO}/releases/tag/${u.tag}`}
+              target="_blank"
+              style={{ color: '#58a6ff', marginLeft: '6px' }}
+            >
+              Release
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default defineWidget({
+  parent: "center-pane",
+  position: 9999,
+  render: () => <UpdateToast />,
+})

--- a/plugins/update-checker/trilium-update-checker.jsx
+++ b/plugins/update-checker/trilium-update-checker.jsx
@@ -3,10 +3,21 @@ import { defineWidget, useState, useEffect } from "trilium:preact";
 const REPO = 'browneyedsoul/trilium-plugins'
 const CHECK_INTERVAL = 24 * 60 * 60 * 1000
 const CACHE_KEY = 'trilium-plugins-update-check'
+const PLUGIN_PREFIX = 'trilium-plugin-'
 
-const PLUGINS = [
-  { name: 'outliner', version: '1.0.0' },
-]
+const getInstalledPlugins = () => {
+  const plugins = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key.startsWith(PLUGIN_PREFIX) && key !== CACHE_KEY) {
+      plugins.push({
+        name: key.slice(PLUGIN_PREFIX.length),
+        version: localStorage.getItem(key),
+      })
+    }
+  }
+  return plugins
+}
 
 const compareVersions = (a, b) => {
   const pa = a.split('.').map(Number)
@@ -31,7 +42,7 @@ const checkForUpdates = async () => {
     const tags = (await res.json()).map(t => t.name)
     const updates = []
 
-    for (const plugin of PLUGINS) {
+    for (const plugin of getInstalledPlugins()) {
       const prefix = `${plugin.name}@`
       const versions = tags
         .filter(t => t.startsWith(prefix))


### PR DESCRIPTION
## Summary

- **Update Checker widget** (Preact JSX): checks GitHub tags against installed plugin versions (auto-detected via localStorage) and shows a toast notification when updates are available
- **Auto-release workflow**: creates `{plugin}@{version}` GitHub releases based on each plugin's `package.json` version on push to main
- **Sync workflow**: automatically merges main back into develop after each merge
- **Outliner**: added `package.json` with version metadata, registers version to localStorage for update detection
- **Branch protection**: deletion prevention ruleset for main and develop

## Test plan

- [ ] Install update-checker as JSX widget in Trilium, verify it loads without errors
- [ ] Install outliner, verify it registers version to localStorage (`trilium-plugin-outliner`)
- [ ] Create a test tag (`outliner@1.1.0`), verify toast notification appears
- [ ] Verify auto-release workflow triggers on merge to main
- [ ] Verify sync-develop workflow merges main back into develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)