### PR TITLE
feat: auto-detect plugins, bump scripts, outliner v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,15 @@
   "name": "trilium-plugins",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "format": "biome format --write .",
     "lint": "biome lint --write .",
-    "check": "biome check --write ."
+    "check": "biome check --write .",
+    "bump:major": "node scripts/bump-version.js major",
+    "bump:minor": "node scripts/bump-version.js minor",
+    "bump:patch": "node scripts/bump-version.js patch"
   },
   "keywords": [],
   "author": "TaurineApps Ltd.",

--- a/plugins/outliner/package.json
+++ b/plugins/outliner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trilium-outliner",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Plugin which automatically indents content based on heading level",
   "author": "browneyedsoul",
   "license": "MIT"

--- a/plugins/outliner/trilium-outliner.js
+++ b/plugins/outliner/trilium-outliner.js
@@ -6,7 +6,7 @@ class OutlineByHeadingWidget extends api.NoteContextAwareWidget {
     return 100
   }
 
-  static get VERSION() { return '1.0.0' }
+  static get VERSION() { return '1.0.1' }
   static get PLUGIN_NAME() { return 'outliner' }
 
   constructor() {

--- a/plugins/outliner/trilium-outliner.js
+++ b/plugins/outliner/trilium-outliner.js
@@ -372,6 +372,9 @@ class OutlineByHeadingWidget extends api.NoteContextAwareWidget {
       .ck-content blockquote p {
           margin-left: unset !important;
       }
+      .ck-content > div > div > div > ul {
+          margin-left: 1.25rem;
+      }
       @media (prefers-color-scheme: dark) {
           .ck-content blockquote {
               background-color: #292e2d !important;

--- a/plugins/update-checker/README.md
+++ b/plugins/update-checker/README.md
@@ -17,6 +17,13 @@ A widget that checks for plugin updates by comparing installed versions against 
 4. Add the label `#widget` to that note.
 5. Refresh Trilium.
 
+## How to Update a Plugin
+
+1. Click the **Release** link in the toast notification.
+2. Copy the latest plugin code from the release page.
+3. Paste it into the existing Code Note in Trilium, replacing the old code.
+4. Refresh Trilium.
+
 ## How It Detects Installed Plugins
 
 Each plugin registers its name and version to localStorage on load (e.g. `trilium-plugin-outliner: "1.0.0"`). The update checker automatically discovers all registered plugins and compares their versions against GitHub tags. No manual configuration needed.

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,0 +1,53 @@
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const [type, plugin] = process.argv.slice(2)
+
+if (!type || !plugin) {
+  console.error('Usage: pnpm bump:<major|minor|patch> <plugin-name>')
+  console.error('Example: pnpm bump:minor outliner')
+  process.exit(1)
+}
+
+const pluginDir = join('plugins', plugin)
+const pkgPath = join(pluginDir, 'package.json')
+
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
+const [major, minor, patch] = pkg.version.split('.').map(Number)
+
+const nextVersion = {
+  major: `${major + 1}.0.0`,
+  minor: `${major}.${minor + 1}.0`,
+  patch: `${major}.${minor}.${patch + 1}`,
+}[type]
+
+if (!nextVersion) {
+  console.error(`Invalid bump type: ${type} (expected major, minor, or patch)`)
+  process.exit(1)
+}
+
+const oldVersion = pkg.version
+pkg.version = nextVersion
+writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
+console.log(`${pkgPath}: ${oldVersion} → ${nextVersion}`)
+
+// Find and update JS/JSX file
+const jsFile = readdirSync(pluginDir).find(f => f.endsWith('.js') || f.endsWith('.jsx'))
+
+if (jsFile) {
+  const jsPath = join(pluginDir, jsFile)
+  const content = readFileSync(jsPath, 'utf-8')
+  const updated = content.replace(
+    /static get VERSION\(\) \{ return '.*?' \}/,
+    `static get VERSION() { return '${nextVersion}' }`,
+  )
+
+  if (content !== updated) {
+    writeFileSync(jsPath, updated)
+    console.log(`${jsPath}: ${oldVersion} → ${nextVersion}`)
+  } else {
+    console.log(`${jsPath}: no VERSION() getter found, skipped`)
+  }
+}
+
+console.log(`Done. ${plugin} bumped to ${nextVersion}`)


### PR DESCRIPTION
## Summary

- **Update checker**: remove manual plugin registry, auto-detect installed plugins from localStorage
- **Bump scripts**: `pnpm bump:major/minor/patch <plugin>` to sync `package.json` and `VERSION` getter
- **Root package.json**: set `"type": "module"`, add bump scripts
- **Update checker**: add package.json, README (with update instructions), logo
- **Outliner**: register version to localStorage, bump to v1.0.1, add nested ul style fix
- **CI**: add sync-develop workflow, auto-release workflow
- **Docs**: update root README with update checker install/update guide

## Test plan

- [ ] Run `pnpm bump:patch outliner` and verify both `package.json` and `VERSION` getter update
- [ ] Install outliner in Trilium, check `trilium-plugin-outliner` appears in localStorage
- [ ] Install update-checker in Trilium, verify it reads from localStorage without manual config
- [ ] After merge, verify auto-release creates `outliner@1.0.1` tag and release
- [ ] After merge, verify sync-develop workflow merges main back into develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)