### PR TITLE
fix(outliner): formatting, CSS fix, and husky setup

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm exec biome check --write --staged

--- a/package.json
+++ b/package.json
@@ -10,13 +10,15 @@
     "check": "biome check --write .",
     "bump:major": "node scripts/bump-version.js major",
     "bump:minor": "node scripts/bump-version.js minor",
-    "bump:patch": "node scripts/bump-version.js patch"
+    "bump:patch": "node scripts/bump-version.js patch",
+    "prepare": "husky"
   },
   "keywords": [],
   "author": "browneyedsoul",
   "license": "MIT",
   "packageManager": "pnpm@10.33.0",
   "devDependencies": {
-    "@biomejs/biome": "2.4.11"
+    "@biomejs/biome": "2.4.11",
+    "husky": "^9.1.7"
   }
 }

--- a/plugins/outliner/package.json
+++ b/plugins/outliner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trilium-outliner",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Plugin which automatically indents content based on heading level",
   "author": "browneyedsoul",
   "license": "MIT"

--- a/plugins/outliner/trilium-outliner.js
+++ b/plugins/outliner/trilium-outliner.js
@@ -6,13 +6,20 @@ class OutlineByHeadingWidget extends api.NoteContextAwareWidget {
     return 100
   }
 
-  static get VERSION() { return '1.0.1' }
-  static get PLUGIN_NAME() { return 'outliner' }
+  static get VERSION() {
+    return '1.0.1'
+  }
+  static get PLUGIN_NAME() {
+    return 'outliner'
+  }
 
   constructor() {
     super()
     this.contentSized()
-    localStorage.setItem(`trilium-plugin-${OutlineByHeadingWidget.PLUGIN_NAME}`, OutlineByHeadingWidget.VERSION)
+    localStorage.setItem(
+      `trilium-plugin-${OutlineByHeadingWidget.PLUGIN_NAME}`,
+      OutlineByHeadingWidget.VERSION
+    )
 
     // ====== 설정 ======
     this.ACTIVATE_LABEL = null // (null 은 어디든 / "outline" 은 #outline 일 때만)
@@ -91,11 +98,11 @@ class OutlineByHeadingWidget extends api.NoteContextAwareWidget {
     if (!el) return null
 
     return (
-      el.closest(".note-detail-pane") || 
-      el.closest(".center-pane") || 
-      el.closest(".split-note-container-widget") || 
+      el.closest('.note-detail-pane') ||
+      el.closest('.center-pane') ||
+      el.closest('.split-note-container-widget') ||
       document
-    );
+    )
   }
 
   _attach(paneRoot) {
@@ -225,20 +232,20 @@ class OutlineByHeadingWidget extends api.NoteContextAwareWidget {
     let didApply = false
 
     // 모든 readonly 컨테이너 찾기 (탭이 여러 개일 때 대응)
-    const roList = scope.querySelectorAll(this.READONLY_SELECTOR);
+    const roList = scope.querySelectorAll(this.READONLY_SELECTOR)
     for (const ro of roList) {
-      if (ro && !ro.closest(".ck-editor__editable")) {
-        this._applyToContainer(ro);
-        didApply = true;
+      if (ro && !ro.closest('.ck-editor__editable')) {
+        this._applyToContainer(ro)
+        didApply = true
       }
     }
 
     // 모든 editable 컨테이너 찾기 (탭이 여러 개일 때 대응)
-    const edList = scope.querySelectorAll(this.EDITABLE_SELECTOR);
+    const edList = scope.querySelectorAll(this.EDITABLE_SELECTOR)
     for (const ed of edList) {
       if (ed) {
-        this._applyToContainer(ed);
-        didApply = true;
+        this._applyToContainer(ed)
+        didApply = true
       }
     }
 
@@ -372,8 +379,11 @@ class OutlineByHeadingWidget extends api.NoteContextAwareWidget {
       .ck-content blockquote p {
           margin-left: unset !important;
       }
-      .ck-content > div > div > div > ul {
+      .ck-content ul {
           margin-left: 1.25rem;
+      }
+      .ck-content ul > li > ul {
+          margin-left: unset;
       }
       @media (prefers-color-scheme: dark) {
           .ck-content blockquote {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.11
         version: 2.4.11
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
 
 packages:
 
@@ -36,24 +39,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.11':
     resolution: {integrity: sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.11':
     resolution: {integrity: sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.11':
     resolution: {integrity: sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.11':
     resolution: {integrity: sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg==}
@@ -66,6 +73,11 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
 snapshots:
 
@@ -103,3 +115,5 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.4.11':
     optional: true
+
+  husky@9.1.7: {}


### PR DESCRIPTION
## Summary
- Add husky pre-commit hook with `biome check --write --staged`
- Apply biome formatting to outliner plugin
- Fix nested list indent CSS (`.ck-content ul` selector)
- Bump outliner version to 1.0.2