### PR TITLE
fix(bump): support multiline VERSION getter

### DIFF
--- a/plugins/outliner/package.json
+++ b/plugins/outliner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trilium-outliner",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A Plugin which automatically indents content based on heading level",
   "author": "browneyedsoul",
   "license": "MIT"

--- a/plugins/outliner/trilium-outliner.js
+++ b/plugins/outliner/trilium-outliner.js
@@ -7,7 +7,7 @@ class OutlineByHeadingWidget extends api.NoteContextAwareWidget {
   }
 
   static get VERSION() {
-    return '1.0.1'
+    return '1.0.3'
   }
   static get PLUGIN_NAME() {
     return 'outliner'

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, readdirSync } from 'node:fs'
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 const [type, plugin] = process.argv.slice(2)
@@ -32,14 +32,14 @@ writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
 console.log(`${pkgPath}: ${oldVersion} → ${nextVersion}`)
 
 // Find and update JS/JSX file
-const jsFile = readdirSync(pluginDir).find(f => f.endsWith('.js') || f.endsWith('.jsx'))
+const jsFile = readdirSync(pluginDir).find((f) => f.endsWith('.js') || f.endsWith('.jsx'))
 
 if (jsFile) {
   const jsPath = join(pluginDir, jsFile)
   const content = readFileSync(jsPath, 'utf-8')
   const updated = content.replace(
     /static get VERSION\(\)\s*\{[\s\S]*?return\s*'.*?'[\s\S]*?\}/,
-    `static get VERSION() {\n    return '${nextVersion}'\n  }`,
+    `static get VERSION() {\n    return '${nextVersion}'\n  }`
   )
 
   if (content !== updated) {

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -38,8 +38,8 @@ if (jsFile) {
   const jsPath = join(pluginDir, jsFile)
   const content = readFileSync(jsPath, 'utf-8')
   const updated = content.replace(
-    /static get VERSION\(\) \{ return '.*?' \}/,
-    `static get VERSION() { return '${nextVersion}' }`,
+    /static get VERSION\(\)\s*\{[\s\S]*?return\s*'.*?'[\s\S]*?\}/,
+    `static get VERSION() {\n    return '${nextVersion}'\n  }`,
   )
 
   if (content !== updated) {


### PR DESCRIPTION
## Summary
- Fix bump script regex to match multiline `VERSION()` getter (biome formatting 이후 매칭 안 되던 문제)
- Apply biome formatting to bump script
- Bump outliner version to 1.0.3