### PR TITLE
fix(ci): attach plugin zip to release asset

### DIFF
--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -33,8 +33,11 @@ jobs:
             git tag "$tag"
             git push origin "$tag"
 
+            (cd plugins/${plugin} && zip -r "../../${plugin}-v${version}.zip" . -x "public/*" "package.json")
+
             gh release create "$tag" \
               --title "$plugin v$version" \
               --notes "Release $plugin v$version" \
-              --target main
+              --target main \
+              "${plugin}-v${version}.zip"
           done

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm exec biome check --write --staged
+pnpm exec biome check --write --staged --no-errors-on-unmatched


### PR DESCRIPTION
## Summary
- Release 시 플러그인 폴더(JS, README)만 zip으로 묶어 asset에 첨부
- `public/`, `package.json` 제외
- pre-commit hook에 `--no-errors-on-unmatched` 추가 (non-js 파일 커밋 시 오류 방지)